### PR TITLE
Make recipe cross-compile capable

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,10 +20,11 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }}
+  host:
     - python
     - cython
     - setuptools
-    - toolchain
   run:
     - python
 


### PR DESCRIPTION
Change to compiler syntax for use with conda build 3.